### PR TITLE
Changed request type to a Post-Request, for the current Slack oauth interface

### DIFF
--- a/src/strategy.js
+++ b/src/strategy.js
@@ -152,7 +152,7 @@ class SlackStrategy extends OAuth2Strategy {
    * @param {Function} done
    */
   userProfile(accessToken, done) {
-    needle.request('get', this.slackAuthOptions.profileURL, { token: accessToken }, (error, response, body) => {
+    needle.request('post', this.slackAuthOptions.profileURL, { token: accessToken }, (error, response, body) => {
       // TODO: better errors
       if (error) {
         done(error);


### PR DESCRIPTION
Hi @aoberoi,

thank you for your great package.
On the search to find the origin for this issue: https://github.com/Requarks/wiki/issues/3149, I recognized that the Slack oauth, actual needs a POST-Request to work: https://api.slack.com/methods/users.identity

This little change should fix the issue.

I hope you have time to merge and build a new version.

Thank you a lot